### PR TITLE
fixed export format to properly show variant fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The following steps are required to launch an annotation task:
 
 ```
     hailctl dataproc submit gnomad-test /local/path/to/hail_annotation.py \ 
-        --config gs://hail-annotation-scripts/test_config.json \ 
-        --region us-west1
+        --config gs://bucket/config.json \ 
+        --region <region, ie us-west-1>
 ```
 
 ### Service Account Permissions

--- a/hail_annotation.py
+++ b/hail_annotation.py
@@ -566,7 +566,7 @@ def hail_annotate(input_df, config):
     vcf = vcf.key_rows_by(vcf.variant)
     
     # export table to HDFS storage
-    export = vcf.select_entries(vcf.efreq, vcf.epopmax, vcf.gfreq, vcf.gpopmax).rows()
+    export = vcf.select_entries(vcf.efreq, vcf.epopmax, vcf.gfreq, vcf.gpopmax).entries()
     output_path = 'hdfs:///tmp/hail-annotate-output.vcf'
     export.export(output_path)
     print(f"Wrote annotated VCF to {output_path}.")


### PR DESCRIPTION
Script was previously exporting `row` fields, dropping variant information contained in `entries` 